### PR TITLE
fix(MFE-2):  Add `build-only` input to action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   pat-token:
     description: 'Github PAT Token'
     required: true
+  build-only:
+    description: 'Only build, do not push assets (true/false)'
+    required: true
 
 runs:
   using: "composite"
@@ -59,11 +62,12 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       with:
         context: .
-        push: false
+        push: ${{ inputs.build-only }}
         build-args: GIT_HASH=${{ env.GIT_SHA }}
         tags: ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ env.GIT_SHA }},${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:latest
     
     - name: Copy static assets from docker container
+      if: ${{ inputs.build-only !== false }}
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
@@ -71,10 +75,12 @@ runs:
       shell: bash
 
     - uses: actions/upload-artifact@v2
+      if: ${{ inputs.build-only !== false }}
       with:
         name: next-static-assets
         path: ./.next
     - uses: actions/upload-artifact@v2
+      if: ${{ inputs.build-only !== false }}
       with:
         name: public-static-assets
         path: ./public

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       with:
         context: .
-        push: ${{ inputs.build-only }}
+        push: ${{ !inputs.build-only }}
         build-args: GIT_HASH=${{ env.GIT_SHA }}
         tags: ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ env.GIT_SHA }},${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:latest
     

--- a/action.yml
+++ b/action.yml
@@ -62,12 +62,12 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       with:
         context: .
-        push: ${{ inputs.build-only == true }}
+        push: ${{ inputs.build-only != true }}
         build-args: GIT_HASH=${{ env.GIT_SHA }}
         tags: ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ env.GIT_SHA }},${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:latest
     
     - name: Copy static assets from docker container
-      if: ${{ inputs.build-only == true }}
+      if: ${{ inputs.build-only != true }}
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
@@ -75,12 +75,12 @@ runs:
       shell: bash
 
     - uses: actions/upload-artifact@v2
-      if: ${{ inputs.build-only == true }}
+      if: ${{ inputs.build-only != true }}
       with:
         name: next-static-assets
         path: ./.next
     - uses: actions/upload-artifact@v2
-      if: ${{ inputs.build-only == true }}
+      if: ${{ inputs.build-only != true }}
       with:
         name: public-static-assets
         path: ./public

--- a/action.yml
+++ b/action.yml
@@ -75,12 +75,12 @@ runs:
       shell: bash
 
     - uses: actions/upload-artifact@v2
-      if: ${{ inputs.build-only !== false }}
+      if: ${{ inputs.build-only == true }}
       with:
         name: next-static-assets
         path: ./.next
     - uses: actions/upload-artifact@v2
-      if: ${{ inputs.build-only !== false }}
+      if: ${{ inputs.build-only == true }}
       with:
         name: public-static-assets
         path: ./public

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}
       with:
         context: .
-        push: ${{ !inputs.build-only }}
+        push: ${{ inputs.build-only == true }}
         build-args: GIT_HASH=${{ env.GIT_SHA }}
         tags: ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ env.GIT_SHA }},${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:latest
     

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         tags: ${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:${{ env.GIT_SHA }},${{ env.ECR_REGISTRY }}/${{ inputs.ecr-repository }}:latest
     
     - name: Copy static assets from docker container
-      if: ${{ inputs.build-only !== false }}
+      if: ${{ inputs.build-only == true }}
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         GIT_SHA: ${{ steps.short-sha.outputs.sha }}


### PR DESCRIPTION
- Adds `build-only` input so the user of the action can specify to only run the build steps and not publish any artifacts (push to ECR or artifacts from the docker build)
- This allows us to use this step for running tests only (e.g. on a PR)