### PR TITLE
fix: Add asset retention days

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,8 +79,10 @@ runs:
       with:
         name: next-static-assets
         path: ./.next
+        retention-days: 1
     - uses: actions/upload-artifact@v2
       if: ${{ inputs.build-only != true }}
       with:
         name: public-static-assets
         path: ./public
+        retention-days: 1


### PR DESCRIPTION
- We don't need to keep these assets for long, so deleting them after 1 day to ensure we don't use too much storage.